### PR TITLE
fixing `baseurl` config for production

### DIFF
--- a/config/production/config.toml
+++ b/config/production/config.toml
@@ -1,2 +1,2 @@
-baseurl = "https://localstack.cloud/"
+baseurl = "https://blog.localstack.cloud/"
 canonifyURLs = false


### PR DESCRIPTION
it seems that when using `{{< img ... >}}` hugo is doing some magic to the image that relies on the `baseurl` prop to be set up correctly. `{{< img-simple >}}` does not do this kind of magic and thus it seems that those are unaffected by the wrong config.

could not really test it locally, but 95% confident that this will solve this.

feel free to merge after approval