### PR TITLE
fix RSS feed

### DIFF
--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -13,7 +13,7 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .RelPermalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range first 25 (where .Site.RegularPages "Type" "in" (slice "jobs" "blog")) }}
+    {{ range first 25 .Site.RegularPages }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .RelPermalink }}</link>


### PR DESCRIPTION
## Motivation
With the extraction of the blog from the website, the [RSS feed](https://blog.localstack.cloud/index.xml) stopped working (it does not show any entries anymore). I know it's old school, but I am still using RSS feeds to keep me up to date for certain pages. Especially for blogs, I think RSS is the perfect tool, and `hugo` supports it out of the box.

This PR fixes this issue by removing a filter on the pages which is not matching anymore after the extraction of the blog.

## Changes
- Remove the filter on `jobs` and `blog` page types. After the extraction, all pages have the type `page`.

## Testing
Here's a comparison:
- [Current RSS feed](https://blog.localstack.cloud/index.xml)
  ```
  <?xml version="1.0" encoding="utf-8" standalone="yes"?>
  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
    <channel>
      <title>LocalStack Blog on LocalStack</title>
      <link>/</link>
      <description>Recent content in LocalStack Blog on LocalStack</description>
      <generator>Hugo -- gohugo.io</generator><language>en-US</language>
      <lastBuildDate>Tue, 06 Oct 2020 08:49:55 +0000</lastBuildDate>
      <atom:link href="[/index.xml](https://blog.localstack.cloud/index.xml)" rel="self" type="application/rss+xml"/>
    </channel>
  </rss>
  ```
  - Note that there are no items listed.
- [New RSS feed](https://localstack-website-preview-pr-13.surge.sh/index.xml)
  ```
  <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
    <channel>
      <title>LocalStack Blog on LocalStack</title>
      ...
      <item>
        <title>Announcing LocalStack 3.0 General Availability!</title>
        ...
      </item>
      ...
    </channel>
  </rss>
  ```