### PR TITLE
fix links in RSS feed

### DIFF
--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -2,7 +2,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <link>{{ .RelPermalink }}</link>
+    <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -11,15 +11,15 @@
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{ with .OutputFormats.Get "RSS" }}
-        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .RelPermalink .MediaType | safeHTML }}
+        {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
     {{ range first 25 .Site.RegularPages }}
     <item>
       <title>{{ .Title }}</title>
-      <link>{{ .RelPermalink }}</link>
+      <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
-      <guid>{{ .RelPermalink }}</guid>
+      <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>
     {{ end }}


### PR DESCRIPTION
## Motivation
Currently, my RSS reader fails to follow links to the LocalStack blog because it does not use the proper subdomain (`blog.localstack.cloud`) but just the main domain name (`localstack.cloud`) which redirects to `www.localstack.cloud`.

This is due to the usage of relative links in the RSS feed:
```xml
<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
  ...
  <link>/</link>
  ...
</rss>
```

## Changes
- Changes the RSS template to have a proper base link in the RSS metadata.

## Testing
- [x] Test the proper links based on the preview deployment.
  - The `index.xml` now contains the correct link to the base URL:
  ```
  <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
    ...
    <link>https://blog.localstack.cloud/...</link>
    ...
  </rss>
  ```
  - The links now work correctly in my feed reader (TTRSS + gfeeds).