### PR TITLE
migrate to localstack auth login

### DIFF
--- a/content/2022-09-12-announcing-localstack-extensions/index.md
+++ b/content/2022-09-12-announcing-localstack-extensions/index.md
@@ -19,7 +19,7 @@ With the LocalStack 1.0 General Availability going live last month, we announced
 LocalStack Extensions is part of our Pro offering. To get started with using LocalStack Extensions, first log in to your account using the LocalStack CLI:
 
 ```bash
-$ localstack login
+$ localstack auth login
 Please provide your login credentials below
 Username: ...
 ```

--- a/content/2023-06-26-develop-your-cloudflare-workers-aws-apps-locally-with-localstack-miniflare/index.md
+++ b/content/2023-06-26-develop-your-cloudflare-workers-aws-apps-locally-with-localstack-miniflare/index.md
@@ -115,7 +115,7 @@ In the following, we describe the detailed installation steps to run the sample 
 To install the LocalStack Cloudflare Extension, we first install the `localstack` CLI on your development machine. To use Extensions with LocalStack, you must have an API key configured (you can [sign-up for a free trial](https://app.localstack.cloud/) to get your API key). Before installing the Extension, log in to your LocalStack account using your username and password:
 
 ```sh
-$ localstack login
+$ localstack auth login
 Please provide your login credentials below
 Username: …
 Password: …


### PR DESCRIPTION
## Motivation
`localstack login` has been deprecated in favor of `localstack auth login` for quite a while (at least `3.0`).

## Changes
This PR changes the usages of `localstack login` in this repo to `localstack auth login`.