### PR TITLE
making blog up to-date with latest changes

### DIFF
--- a/content/2021-05-06-localstack-40k-stars/index.md
+++ b/content/2021-05-06-localstack-40k-stars/index.md
@@ -161,7 +161,7 @@ one-click-deployments of LocalStack on Shipyard in a follow-up blog post soon.
 We're excited to announce that we are going multi-cloud - focusing on
 Azure APIs as the next cloud layer, based on all the learnings we have
 gathered in our journey so far. If you'd like to participate in our
-*Azure beta program*, please get in touch with us directly.
+*Azure preview program*, please get in touch with us directly.
 
 But it doesn't stop there. More and more of our users are asking
 for LocalStack to support AI apps - we feel the pain of AI engineers

--- a/content/2022-02-07-localstack-cockpit/index.md
+++ b/content/2022-02-07-localstack-cockpit/index.md
@@ -21,7 +21,7 @@ The new [LocalStack Cockpit](https://localstack.cloud/products/cockpit/) is now 
 
 ## Getting started
 
-You can now download the LocalStack Cockpit from our [website](https://localstack.cloud) by signing up for our v0.1.0 beta release. You can choose the platform you would like to try LocalStack Cockpit on and enter the email address so that we can send you the download link. After downloading LocalStack Cockpit, you can get started with running it on your machine and increase your development productivity.
+You can now download the LocalStack Cockpit from our [website](https://localstack.cloud) by signing up for our v0.1.0 preview release. You can choose the platform you would like to try LocalStack Cockpit on and enter the email address so that we can send you the download link. After downloading LocalStack Cockpit, you can get started with running it on your machine and increase your development productivity.
 
 {{< img src="localstack-cockpit-start.gif" >}}
 
@@ -38,6 +38,6 @@ Navigate to our [documentation](https://docs.localstack.cloud/get-started/cockpi
 
 ## What's next?
 
-We’re excited to share the beta version of LocalStack Cockpit with you, while we work on iterating further, adding new features, fixing bugs and helping your LocalStack workflow become as seamless as possible. We are planning to extend the functionality over the initial version, over the next couple of months - stay tuned!
+We’re excited to share the preview version of LocalStack Cockpit with you, while we work on iterating further, adding new features, fixing bugs and helping your LocalStack workflow become as seamless as possible. We are planning to extend the functionality over the initial version, over the next couple of months - stay tuned!
 
 You can read more about our product on the LocalStack Cockpit product page and send us your bug reports, feature requests and your general feedback on our [GitHub repository](https://github.com/localstack/cockpit/issues). We’re looking forward to getting your feedback!

--- a/content/2022-02-07-localstack-cockpit/index.md
+++ b/content/2022-02-07-localstack-cockpit/index.md
@@ -12,6 +12,11 @@ leadimage: "localstack-cockpit-banner.png"
 
 {{< img src="localstack-cockpit-banner.png" >}}
 
+{{< alert title="Note" >}}
+📢 LocalStack Cockpit has been deprecated and isn’t available or maintained anymore and we recommend you to use [LocalStack Desktop](https://docs.localstack.cloud/user-guide/tools/localstack-desktop/) instead.
+{{< /alert >}}
+<br>
+
 The new [LocalStack Cockpit](https://localstack.cloud/products/cockpit/) is now available. LocalStack Cockpit is a fully-integrated desktop experience for our LocalStack users. It allows our users to control, access, and manage LocalStack with a click of a button. No matter if you are a seasoned LocalStack user or just starting up to use LocalStack, Cockpit helps you use LocalStack more effectively!
 
 ## Getting started

--- a/content/2022-04-22-localstack-40k-stars-90m-pulls-and-an-engaged-community/index.md
+++ b/content/2022-04-22-localstack-40k-stars-90m-pulls-and-an-engaged-community/index.md
@@ -72,7 +72,7 @@ To further support team collaboration, the next exciting product we are pushing 
 
 We are supporting seamless integrations across your CI/CD systems, and LocalStack is compatible with all major CI providers like GitHub Actions, TravisCI, CircleCI, GitLab CI and Jenkins. Soon you will also be able to sync the state and test data from production directly into your development/CI environments. Development teams can then  capitalize on the Local Cloud Pods storage backend by pushing or pulling the application state and collaborating with team members on the shared state.
 
-We now also feature beta releases of the LocalStack Cockpit as well as our new CI Time Travel Analytics product, which allows you to visualize your CI runs directly in your browser. The [LocalStack Cockpit](https://localstack.cloud/products/cockpit/) brings a Desktop experience for managing your LocalStack instance to your local machine. In the Cockpit, you can inspect the service status, debug logs, define configuration profiles, and more. Try it out by downloading LocalStack Cockpit!
+We now also feature preview release of the LocalStack Cockpit as well as our new CI Time Travel Analytics product, which allows you to visualize your CI runs directly in your browser. The [LocalStack Cockpit](https://localstack.cloud/products/cockpit/) brings a Desktop experience for managing your LocalStack instance to your local machine. In the Cockpit, you can inspect the service status, debug logs, define configuration profiles, and more. Try it out by downloading LocalStack Cockpit!
 
 {{< img src="localstack-cockpit.png" >}}
 

--- a/content/2022-09-12-announcing-localstack-extensions/index.md
+++ b/content/2022-09-12-announcing-localstack-extensions/index.md
@@ -151,6 +151,6 @@ The sky is the limit!
 
 ## Conclusion
 
-LocalStack Extensions is currently in Beta and is continually evolving. We use the [Discussion Pages](https://discuss.localstack.cloud/) to share updates on our product and to communicate the roadmap. We look forward to working closely with our growing community and engaging via Discussion Pages on all the upcoming exciting upcoming topics and upcoming updates.
+LocalStack Extensions is currently in preview and is continually evolving. We use the [Discussion Pages](https://discuss.localstack.cloud/) to share updates on our product and to communicate the roadmap. We look forward to working closely with our growing community and engaging via Discussion Pages on all the upcoming exciting upcoming topics and upcoming updates.
 
 Let’s work together to create a superb developer experience and make cloud development fun! 🚀

--- a/content/2023-03-29-announcing-localstack-2.0-general-availability/index.md
+++ b/content/2023-03-29-announcing-localstack-2.0-general-availability/index.md
@@ -125,7 +125,7 @@ Over the past few months, we have introduced & improved LocalStack Tools to make
 
 We have launched the [Developer Hub](https://docs.localstack.cloud/developer-hub/), a new Web experience enabling developers to find up-to-date LocalStack samples spanning various use cases: Serverless, Containers, Big Data, Identity, and much more! The Developer Hub offers a consolidated view of [LocalStack sample applications](https://docs.localstack.cloud/applications) that educate developers to build and run cloud and serverless applications. With additional [tutorials](https://docs.localstack.cloud/tutorials), we strive to keep the gap between LocalStack and AWS as small as possible and focus on getting users, step by step, started with LocalStack!
 
-The Developer Hub is currently in beta and available on our [documentation website](https://docs.localstack.cloud/developer-hub/).
+The Developer Hub is currently in preview and available on our [documentation website](https://docs.localstack.cloud/developer-hub/).
 We are increasingly improving our sample applications' quality and service coverage while actively seeking user feedback.
 In the future, we would like to expand this concept to include explainer videos, lab environments, broader code samples, and more blog posts, making it the resource go-to for our community.
 To learn more about the Developer Hub and the purpose it serves, check out our [discuss post](https://discuss.localstack.cloud/t/introducing-the-localstack-developer-hub/264).

--- a/content/2023-09-07-localstack-has-joined-aws-marketplace-to-streamline-local-cloud-development-testing/index.md
+++ b/content/2023-09-07-localstack-has-joined-aws-marketplace-to-streamline-local-cloud-development-testing/index.md
@@ -8,7 +8,6 @@ contributors: ["LocalStack Team"]
 tags: ['news']
 leadimage: "localstack-joins-aws-marketplace.png"
 show_cta_1: true
-weight: 5
 ---
 
 {{< img-simple src="localstack-joins-aws-marketplace.png" >}}

--- a/content/2023-11-09-introducing-localstack-desktop-application-for-local-cloud-development-testing/index.md
+++ b/content/2023-11-09-introducing-localstack-desktop-application-for-local-cloud-development-testing/index.md
@@ -19,7 +19,7 @@ We are excited to announce that we have released an all-new [Desktop Application
 
 ## What's new?
 
-Last year, we released [LocalStack Cockpit](https://localstack.cloud/blog/2022-02-07-localstack-cockpit/) — our first iteration towards building a fully integrated desktop client to control, access, and manage LocalStack with a click of a button. We received a lot of feedback from the community during the beta phase, and after spending months working on it, we formulated a new product for our users to use LocalStack more efficiently.
+Last year, we released [LocalStack Cockpit](https://localstack.cloud/blog/2022-02-07-localstack-cockpit/) — our first iteration towards building a fully integrated desktop client to control, access, and manage LocalStack with a click of a button. We received a lot of feedback from the community during the preview phase, and after spending months working on it, we formulated a new product for our users to use LocalStack more efficiently.
 
 To further streamline our product offering, we've made the decision to deprecate LocalStack Cockpit for new users. Going forward, we will help migrate our existing users and get our new users started with to the LocalStack Desktop Application.
 

--- a/content/2023-11-16-announcing-localstack-30-general-availability/index.md
+++ b/content/2023-11-16-announcing-localstack-30-general-availability/index.md
@@ -38,8 +38,8 @@ Let's take a look at our latest release's new features and enhancements to see h
 * [New ElastiCache provider](#new-elasticache-provider)
 * [New features for Chaos Engineering](#new-features-for-chaos-engineering)
 * [IAM Policy Stream on Web Application](#iam-policy-stream-on-web-application)
-* [Ephemeral Environments for LocalStack](#ephemeral-environments-for-localstack-beta) (**Beta**)
-* [CI Analytics for LocalStack](#ci-analytics-for-localstack-beta) (**Beta**)
+* [Ephemeral Environments for LocalStack](#ephemeral-environments-for-localstack-preview) (**Preview**)
+* [CI Analytics for LocalStack](#ci-analytics-for-localstack-preview) (**Preview**)
 * [All-new LocalStack Desktop Application](#all-new-localstack-desktop-application)
 * [Multi-region and Multi-account support](#multi-region-and-multi-account-support)
 * [LocalStack Networking initiative](#localstack-networking-initiative)
@@ -103,7 +103,7 @@ The features include:
 
 Check out our [documentation](https://docs.localstack.cloud/user-guide/security-testing/iam-policy-stream/) on getting started with the IAM Policy Stream.
 
-### Ephemeral Environments for LocalStack (**Beta**)
+### Ephemeral Environments for LocalStack (**Preview**)
 
 We have launched **Ephemeral Instances**, which allows you to run a LocalStack sandbox in the cloud, instead of your local machine. This ephemeral environment is a short-lived, encapsulated deployment of LocalStack which will be terminated after 90 minutes. With these sandboxes, you can run your tests, preview features in your AWS-powered applications, and collaborate asynchronously within and across your team!
 
@@ -111,9 +111,9 @@ With Ephemeral Instances, you can use the same set of features that you use whil
 
 {{< img-simple src="localstack-ephemeral-environments.png" width=300 alt="Image of LocalStack Ephemeral environments with a LocalStack Sandbox running in the cloud">}}
 
-Check out our [documentation](https://docs.localstack.cloud/user-guide/cloud-sandbox/ephemeral-instance/) on getting started with Ephemeral Instances. The feature is in **private beta**, and you can reach out to us to get early access!
+Check out our [documentation](https://docs.localstack.cloud/user-guide/cloud-sandbox/ephemeral-instance/) on getting started with Ephemeral Instances. The feature is in **private preview**, and you can reach out to us to get early access!
 
-### CI Analytics for LocalStack (**Beta**)
+### CI Analytics for LocalStack (**Preview**)
 
 We're excited to introduce **CI Analytics**, a new feature for comprehensive state browsing and analysis of historical continuous integration (CI) builds. This feature integrates into your LocalStack CI workflow, offering insights and supporting our goal to enhance the cloud developer experience throughout the software development lifecycle (SDLC). With CI Analytics, you can collect, analyze, and visualize critical metrics from your software CI pipelines, helping you understand the impact of cloud infrastructure changes on CI builds. It facilitates root cause analysis for build failures, supports data-driven decisions for continuous improvement, and more.
 
@@ -127,7 +127,7 @@ CI Analytics combines a number of existing features in the LocalStack platform, 
 
 {{< img-simple src="localstack-ci-analytics.png" width=300 alt="Image of LocalStack CI Analytics dashboard">}}
 
-Check out our [documentation](https://docs.localstack.cloud/user-guide/ci/ci-analytics/) on getting started with CI Analytics. The feature is in **private beta**, and you can reach out to us to get early access!
+Check out our [documentation](https://docs.localstack.cloud/user-guide/ci/ci-analytics/) on getting started with CI Analytics. The feature is in **private preview**, and you can reach out to us to get early access!
 
 ### All-new LocalStack Desktop Application
 

--- a/content/2023-11-27-ten-things-you-need-to-know-about-localstack/index.md
+++ b/content/2023-11-27-ten-things-you-need-to-know-about-localstack/index.md
@@ -9,7 +9,6 @@ contributors: ["Anca Ghenade"]
 tags: ['showcase']
 show_cta_1: true
 leadimage: '10-things-to-know.png'
-weight: 3
 ---
 
 


### PR DESCRIPTION
This PR:

- Adds deprecation notice on Cockpit blog
- Removes assigned weight on re:Invent & AWS Marketplace blog
- Replaces **Beta** tag with **Preview** 