### PR TITLE
assign proper weights to the blogs

### DIFF
--- a/content/2022-08-04-parity-explained/index.md
+++ b/content/2022-08-04-parity-explained/index.md
@@ -8,7 +8,7 @@ images: []
 contributors: ["Stefanie", "Dominik", "Thomas"]
 tags: ['news']
 leadimage: "localstack-and-aws-parity-explained.png"
-weight: 4
+weight: 5
 ---
 
 {{< img src="localstack-and-aws-parity-explained.png" >}}

--- a/content/2024-01-03-celebrating-50k-github-stars-localstack/index.md
+++ b/content/2024-01-03-celebrating-50k-github-stars-localstack/index.md
@@ -8,7 +8,7 @@ images: ['50k-github-stars-localstack.png']
 leadimage: '50k-github-stars-localstack.png'
 tags: ['news']
 contributors: ["Waldemar Hummer", "Harsh Mishra"]
-weight: 2
+weight: 4
 ---
 
 {{< img-simple src="50k-github-stars-localstack.png" width=300 alt="A LocalStack banner indicating 50k stars">}}

--- a/content/2024-02-20-cloud-pods-local-to-ci-and-testcontainers/index.md
+++ b/content/2024-02-20-cloud-pods-local-to-ci-and-testcontainers/index.md
@@ -8,7 +8,7 @@ images: ['cloud-pods-2024.png']
 leadimage: 'cloud-pods-2024.png'
 contributors: ["Anca Ghenade"]
 tags: ['showcase']
-weight: 2
+weight: 3
 ---
 
 {{< img-simple src="cloud-pods-2024.png" width=300 alt="A LocalStack Cloud Pods banner">}}

--- a/content/2024-05-22-introducing-localstack-for-snowflake/index.md
+++ b/content/2024-05-22-introducing-localstack-for-snowflake/index.md
@@ -10,6 +10,7 @@ tags: ['news']
 show_cta_1: true
 images: ["introducing-localstack-for-snowflake.png"]
 leadimage: "introducing-localstack-for-snowflake.png"
+weight: 2
 ---
 
 {{< img-simple src="introducing-localstack-for-snowflake.png" width=300 alt="Banner image for the blog: Introducing LocalStack for Snowflake: The new emulator to build & test data pipelines locally">}}


### PR DESCRIPTION
This PR adds new weights the blog in the following order:

- LocalStack 3.0 
- Snowflake preview
- Cloud Pods 
- 50K GitHub Stars 
- AWS Parity explained