### PR TITLE
fix bold font for LB link

### DIFF
--- a/content/2024-07-04-develop-cloud-ai-with-ollama-localstack/index.md
+++ b/content/2024-07-04-develop-cloud-ai-with-ollama-localstack/index.md
@@ -333,7 +333,7 @@ generate, and then it is fully received.
 
 {{< img-simple src=ollama-call.png width=300 alt="App locally">}}
 
-The backend call will be made to the **load balancer**, at [**`http://ecs-load-balancer.elb.localhost.localstack.cloud:4566/api/generate/`**](http://ecs-load-balancer.elb.localhost.localstack.cloud:4566/api/generate/), so we don't have to worry
+The backend call will be made to the **load balancer**, at [`http://ecs-load-balancer.elb.localhost.localstack.cloud:4566/api/generate/`](http://ecs-load-balancer.elb.localhost.localstack.cloud:4566/api/generate/), so we don't have to worry
 about how we access the task containers.
 
 


### PR DESCRIPTION
this renders correct when built locally, but on the actual blog, it shows the markdown syntax.